### PR TITLE
Update encrypt blobstore buckets

### DIFF
--- a/monitoring.yml
+++ b/monitoring.yml
@@ -93,7 +93,11 @@ properties:
     hostname_prefix: (( meta.environment "." ))
     riemann_server: (( meta.collectd.riemann_server ))
   encrypt-blobstore:
-    bucket: "18f-cf-green-blobstore"
+    buckets:
+    - "18f-boshrelease-blob"
+    - "cloud-gov-bosh-releases"
+    - "cloud-gov-varz"
+    - "cloud-gov-varz-stage"
     access_key: (( meta.aws.access_key_id ))
     secret_access_key: (( meta.aws.secret_access_key ))
   grafana:

--- a/monitoring.yml
+++ b/monitoring.yml
@@ -98,6 +98,7 @@ properties:
     - "cloud-gov-bosh-releases"
     - "cloud-gov-varz"
     - "cloud-gov-varz-stage"
+    - "18f-cf-green-blobstore"
     access_key: (( meta.aws.access_key_id ))
     secret_access_key: (( meta.aws.secret_access_key ))
   grafana:


### PR DESCRIPTION
This patch series statically adds the `s3` buckets needed by the updates to `encrypt-blobstores-boshrelease` here 18F/cg-encrypt-blobstore-boshrelease#1
