### PR TITLE
Set secure cookies in grafana.

### DIFF
--- a/monitoring.yml
+++ b/monitoring.yml
@@ -98,6 +98,8 @@ properties:
       user: root
   grafana:
     listen_port: 3000
+    session:
+      cookie_secure: "true"
     auth:
       github:
         enabled: true


### PR DESCRIPTION
This will configure grafana to use secure cookies once https://github.com/vito/grafana-boshrelease/pull/17 is merged.