### PR TITLE
Use consistent metrics scope name.

### DIFF
--- a/monitoring.yml
+++ b/monitoring.yml
@@ -85,7 +85,7 @@ properties:
       generic_oauth:
         enabled: true
         allow_sign_up: true
-        scopes: [openid,monitoring.read]
+        scopes: [openid,metrics.read]
     datasources:
     - type: "influxdb"
       database: (( grab properties.influxdb.database ))


### PR DESCRIPTION
To match scopes defined in
https://github.com/18F/cg-deploy-bosh/blob/master/tooling-uaa.yml#L23-L32.

This won't have any practical effect at the moment, but will be useful once https://github.com/grafana/grafana/issues/6809 is resolved.