### PR TITLE
add lock to check_awslogs cron job and...

### DIFF
--- a/monitoring.yml
+++ b/monitoring.yml
@@ -41,6 +41,7 @@ jobs:
       - script:
           name: check_awslogs.sh
           contents: (( file "cronjobs/check_awslogs.sh" ))
+        lock: /var/vcap/sys/run/cron/check_awslogs.lock
         minute: '*/5'
         hour: '*'
         day: '*'
@@ -127,6 +128,14 @@ properties:
       content: (( file "dashboards-tmp/pods.json" ))
 
   riemann:
+    memory:
+      overrides:
+      - host: '^queue.\d+'
+        threshold: 50
+        state: critical
+      - host: '^queue.\d+'
+        threshold: 25
+        state: warn
     swap:
       critical: 25
       warn: 10
@@ -172,11 +181,11 @@ resource_pools:
 
 disk_pools:
 - name: riemann
-  disk_size: 30_000
+  disk_size: 5_000
   cloud_properties:
     encrypted: true
 - name: influxdb
-  disk_size: 500_000
+  disk_size: 150_000
   cloud_properties:
     encrypted: true
 


### PR DESCRIPTION
add logsearch queue specific memory checks; shrink persistent disks

Set riemann persistent disk to 5GB as that's where we write hprof dumps if riemann goes OOM and they can be as large as memory on the system

Set influxdb disk size based on retention policy == 180 days, and we are currently using 44GB of data with 90 days stored.

cc: https://github.com/18F/cg-atlas/issues/196