### PR TITLE
2GB heap size for riemann

### DIFF
--- a/monitoring.yml
+++ b/monitoring.yml
@@ -167,6 +167,8 @@ properties:
       content: (( file "dashboards-tmp/pods.json" ))
 
   riemann:
+    java:
+      xmx: 2048m
     memory:
       overrides:
       - host: '^queue.\d+'


### PR DESCRIPTION
The riemann heap size was recently increased by adding this setting to the secrets, as it's not secret we should have it in the manifest.

When this PR is merged, the corresponding entry should also be removed from the secrets.