### PR TITLE
Bump influxdb disk slightly to fit retention

### DIFF
--- a/monitoring.yml
+++ b/monitoring.yml
@@ -249,7 +249,7 @@ disk_pools:
   cloud_properties:
     encrypted: true
 - name: influxdb
-  disk_size: 175_000
+  disk_size: 200_000
   cloud_properties:
     encrypted: true
 


### PR DESCRIPTION
Running up against alerting for disk space, bumping this slightly should solve for current retention requirements. 
