### PR TITLE
lint monitoring bosh manifest before deploy

### DIFF
--- a/bosh-lint.yml
+++ b/bosh-lint.yml
@@ -1,0 +1,2 @@
+static_ips:
+  disable: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -46,6 +46,14 @@ jobs:
             terraform-yaml/state.yml \
             common/secrets.yml \
             > monitoring-manifest/manifest.yml
+  - &lint-manifest
+    task: lint-manifest
+    file: pipeline-tasks/lint-manifest.yml
+    input_mapping:
+      pipeline-config: monitoring-config
+      lint-manifest: monitoring-manifest
+    params:
+      LINTER_CONFIG: bosh-lint.yml
   - put: monitoring-staging-deployment
     params: &deploy-params
       cert: master-bosh-root-cert/master-bosh.crt
@@ -117,6 +125,7 @@ jobs:
             terraform-yaml/state.yml \
             common/secrets.yml \
             > monitoring-manifest/manifest.yml
+  - *lint-manifest
   - put: monitoring-production-deployment
     params: *deploy-params
   on_failure:


### PR DESCRIPTION
Lint monitoring bosh manifest before deploy into staging and prod
Disable static_ips check in linter