### PR TITLE
quiet influx memory errors

### DIFF
--- a/monitoring.yml
+++ b/monitoring.yml
@@ -100,6 +100,12 @@ instance_groups:
           xmx: 2048m
         memory:
           overrides:
+          - host: 'influxdb.\d+'
+            threshold: 100
+            state: critical
+          - host: 'influxdb.\d+'
+            threshold: 98
+            state: warn
           - host: '^queue.\d+'
             threshold: 50
             state: critical


### PR DESCRIPTION
I'll roll this back in a couple of weeks once the retention policy has had time to lower the average shard size.

