### PR TITLE
actually quiet influx alerts

### DIFF
--- a/monitoring.yml
+++ b/monitoring.yml
@@ -101,10 +101,7 @@ instance_groups:
         memory:
           overrides:
           - host: 'influxdb.\d+'
-            threshold: 100
-            state: critical
-          - host: 'influxdb.\d+'
-            threshold: 98
+            threshold: 89
             state: warn
           - host: '^queue.\d+'
             threshold: 50


### PR DESCRIPTION
Due to the way this alert is currently constructed we need this override to be less than the default critical (90) threshold or it won't take effect and we'll still be alerted when influxdb uses > 90% of memory.